### PR TITLE
Fix path encoding in CURL driver

### DIFF
--- a/src/Driver/CurlDriver.php
+++ b/src/Driver/CurlDriver.php
@@ -20,7 +20,7 @@ class CurlDriver implements ISizeDriver
 	 */
 	public function getFileSize($path)
 	{
-		$ch = curl_init("file://" . urlencode($path));
+		$ch = curl_init("file://" . rawurlencode($path));
 		curl_setopt($ch, CURLOPT_NOBODY, true);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_HEADER, true);


### PR DESCRIPTION
I have found that file size is defined wrong in CURL driver if filename contains gaps and encoded with **urlencode()**. The solution is to use **rawurlencode()** instead. It is easy to reproduse. Check the difference:

urlencode result:
`%2Fuserfiles%2FThe+File+Encoded.mkv`

rawurlencode result:
`%2Fuserfiles%2FThe%20File%20Encoded.mkv`

The **rawurlencode()** gives correct result.
Tested on file > 4GB on 32-bit system.